### PR TITLE
Fixed backend query

### DIFF
--- a/backend/routes/search.py
+++ b/backend/routes/search.py
@@ -17,7 +17,7 @@ router = APIRouter(tags=["search"])
 async def search_knowledge(query_string: str):
     response_data: List[Dict[str, str]] = []
 
-    query = Q('multi_match', description=query_string) or Q('match', title=query_string)
+    query = Q('multi_match', query=query_string, fields=['title', 'description', 'resolution'])
     search = Search(index='knowledge-index').query(query)
     search_response = search.execute()
     for hit in search_response:


### PR DESCRIPTION
It looks like you need to use the `multi_match` option in the query and then add the fields to search as a list. I just went off the example from the **elasticsearch-dsl** documentation and it seems to be working.

Old:
```python
query = Q('match', description=query_string) or Q('match', title=query_string)
```

New
```python
query = Q('multi_match', query=query_string, fields=['title', 'description', 'resolution'])
```